### PR TITLE
No longer requires authentication via Username & Password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,14 +21,17 @@ pip-log.txt
 .coverage
 .tox
 
-#Translations
+# Translations
 *.mo
 
 
-#Virtualenv
+# Virtualenv
 env/
 
-#Editor temporaries
+# Editor temporaries
 *~
 
 *.db
+
+# PyCharm
+.idea

--- a/example/app.py
+++ b/example/app.py
@@ -19,10 +19,6 @@ users = [
 username_table = {u.username: u for u in users}
 userid_table = {u.id: u for u in users}
 
-def authenticate(username, password):
-    user = username_table.get(username, None)
-    if user and safe_str_cmp(user.password.encode('utf-8'), password.encode('utf-8')):
-        return user
 
 def identity(payload):
     user_id = payload['identity']
@@ -32,7 +28,14 @@ app = Flask(__name__)
 app.debug = True
 app.config['SECRET_KEY'] = 'super-secret'
 
-jwt = JWT(app, authenticate, identity)
+jwt = JWT(app, identity_handler=identity)
+
+@jwt.authentication_handler
+def authenticate(username, password, **kwargs):
+    user = username_table.get(username, None)
+    if user and safe_str_cmp(user.password.encode('utf-8'), password.encode('utf-8')):
+        return user
+
 
 @app.route('/protected')
 @jwt_required()
@@ -40,4 +43,4 @@ def protected():
     return '%s' % current_identity
 
 if __name__ == '__main__':
-    app.run()
+    app.run(host='localhost')

--- a/example/app.py
+++ b/example/app.py
@@ -9,7 +9,7 @@ class User(object):
         self.password = password
 
     def __str__(self):
-        return "User(id='%s')" % self.id
+        return "User(id='{}')".format(self.id)
 
 users = [
     User(1, 'user1', 'abcxyz'),
@@ -43,7 +43,7 @@ def authenticate(username, password, **kwargs):
 @app.route('/protected')
 @jwt_required()
 def protected():
-    return '%s' % current_identity
+    return '{}'.format(current_identity)
 
 if __name__ == '__main__':
     app.run(host='localhost')

--- a/example/app.py
+++ b/example/app.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from flask_jwt import JWT, jwt_required, current_identity
+from flask_jwt import JWT, current_identity
 from werkzeug.security import safe_str_cmp
 
 class User(object):
@@ -41,7 +41,7 @@ def authenticate(username, password, **kwargs):
 
 
 @app.route('/protected')
-@jwt_required()
+@jwt.jwt_required()
 def protected():
     return '{}'.format(current_identity)
 

--- a/example/app.py
+++ b/example/app.py
@@ -20,15 +20,18 @@ username_table = {u.username: u for u in users}
 userid_table = {u.id: u for u in users}
 
 
-def identity(payload):
-    user_id = payload['identity']
-    return userid_table.get(user_id, None)
-
 app = Flask(__name__)
 app.debug = True
 app.config['SECRET_KEY'] = 'super-secret'
 
-jwt = JWT(app, identity_handler=identity)
+jwt = JWT(app)
+
+
+@jwt.identity_handler
+def identity(payload):
+    user_id = payload['identity']
+    return userid_table.get(user_id, None)
+
 
 @jwt.authentication_handler
 def authenticate(username, password, **kwargs):

--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -160,14 +160,19 @@ def _default_jwt_required_handler(*args, **kwargs):
 
     :param realm: an optional realm
     """
-    try:
-        realm = args[0] or kwargs['realm']
-    except IndexError:
+
+    if 0 <= len(args):
+        realm = args[0]
+    elif 'roles' in kwargs:
+        realm = kwargs['realm']
+    else:
         realm = current_app.config['JWT_DEFAULT_REALM']
 
-    try:
-        roles = args[1] or kwargs['roles']
-    except IndexError:
+    if 1 <= len(args):
+        roles = args[1]
+    elif 'roles' in kwargs:
+        roles = kwargs['roles']
+    else:
         roles = None
 
     token = _jwt.request_callback()

--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -161,14 +161,14 @@ def _default_jwt_required_handler(*args, **kwargs):
     :param realm: an optional realm
     """
 
-    if 0 <= len(args):
+    if 0 < len(args):
         realm = args[0]
-    elif 'roles' in kwargs:
+    elif 'realm' in kwargs:
         realm = kwargs['realm']
     else:
         realm = current_app.config['JWT_DEFAULT_REALM']
 
-    if 1 <= len(args):
+    if 1 < len(args):
         roles = args[1]
     elif 'roles' in kwargs:
         roles = kwargs['roles']

--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -62,7 +62,7 @@ def _default_jwt_encode_handler(identity):
     missing_claims = list(set(required_claims) - set(payload.keys()))
 
     if missing_claims:
-        raise RuntimeError('Payload is missing required claims: %s' % ', '.join(missing_claims))
+        raise RuntimeError('Payload is missing required claims: {}'.format(', '.join(missing_claims)))
 
     headers = _jwt.jwt_headers_callback(identity)
 
@@ -88,8 +88,7 @@ def _default_jwt_decode_handler(token):
         for claim in ['exp', 'nbf', 'iat']
     })
 
-    return jwt.decode(token, secret, options=options, algorithms=[algorithm], leeway=leeway,
-                      audience=audience)
+    return jwt.decode(token, secret, options=options, algorithms=[algorithm], leeway=leeway, audience=audience)
 
 
 def _default_request_handler():
@@ -165,7 +164,7 @@ def _jwt_required(realm, roles):
 
     if token is None:
         raise JWTError('Authorization Required', 'Request does not contain an access token',
-                       headers={'WWW-Authenticate': 'JWT realm="%s"' % realm})
+                       headers={'WWW-Authenticate': 'JWT realm="{}"'.format(realm)})
 
     try:
         payload = _jwt.jwt_decode_callback(token)
@@ -216,10 +215,10 @@ class JWTError(Exception):
         self.headers = headers
 
     def __repr__(self):
-        return 'JWTError: %s' % self.error
+        return 'JWTError: {}'.format(self.error)
 
     def __str__(self):
-        return '%s. %s' % (self.error, self.description)
+        return '{}. {}'.format(self.error, self.description)
 
 
 def encode_token():

--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -116,14 +116,10 @@ def _default_auth_request_handler():
     if not isinstance(data, dict):  # Strings/arrays, or non-JSON mimetype
         raise JWTError('Bad Request', 'Credentials must supplied in JSON')
 
-    username = data.get(current_app.config.get('JWT_AUTH_USERNAME_KEY'))
-    password = data.get(current_app.config.get('JWT_AUTH_PASSWORD_KEY'))
-    criterion = [username, password, len(data) == 2]
-
-    if not all(criterion):
+    try:
+        identity = _jwt.authentication_callback(**data)
+    except TypeError:
         raise JWTError('Bad Request', 'Invalid credentials')
-
-    identity = _jwt.authentication_callback(username, password)
 
     if identity:
         access_token = _jwt.jwt_encode_callback(identity)

--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -119,7 +119,7 @@ def _default_auth_request_handler():
     try:
         identity = _jwt.authentication_callback(**data)
     except TypeError:
-        raise JWTError('Bad Request', 'Invalid credentials')
+        raise JWTError('Bad Request', 'Invalid credentials arguments')
 
     if identity:
         access_token = _jwt.jwt_encode_callback(identity)
@@ -253,10 +253,10 @@ class JWT(object):
         endpoint = app.config.get('JWT_AUTH_ENDPOINT', None)
 
         if auth_url_rule and endpoint:
-            if self.auth_request_callback == _default_auth_request_handler:
-                assert self.authentication_callback is not None, (
-                    'an authentication_handler function must be defined when using the built in '
-                    'authentication resource')
+            # if self.auth_request_callback == _default_auth_request_handler:
+            #     assert self.authentication_callback is not None, (
+            #         'an authentication_handler function must be defined when using the built in '
+            #         'authentication resource')
 
             auth_url_options = app.config.get('JWT_AUTH_URL_OPTIONS', {'methods': ['POST']})
             auth_url_options.setdefault('view_func', self.auth_request_callback)


### PR DESCRIPTION
I've changed around a few things so the initial authentication to get the JWT no longer has to be a Username & Password.  Instead you can use whatever you like as defined in the @jwt.authentication_handler's function params.

(A use case for this would be if the authentication was via OAuth)